### PR TITLE
chore: add pip requirements.txt

### DIFF
--- a/Time_Banking/requirements.txt
+++ b/Time_Banking/requirements.txt
@@ -1,0 +1,2 @@
+Django==5.1.1
+python-decouple==3.8


### PR DESCRIPTION
This just adds the list of dependencies so that `pip install -r requirements.txt` actually works