### PR TITLE
Entry point for creating listings

### DIFF
--- a/Time_Banking/Time_Banking/settings.py
+++ b/Time_Banking/Time_Banking/settings.py
@@ -155,3 +155,6 @@ LOGOUT_REDIRECT_URL = "/"
 AUTH_USER_MODEL = "Time_Banking.User"
 
 CSRF_TRUSTED_ORIGINS = ["https://time-banking.bus-hit.me"]
+
+DISABLE_RATE_LIMIT_CHECK = False
+

--- a/Time_Banking/Time_Banking/static/css/style.css
+++ b/Time_Banking/Time_Banking/static/css/style.css
@@ -591,3 +591,32 @@ label {
     object-fit: cover;
     border: 3px solid #11407e ;
 }
+
+
+#create_listing_btn {
+    margin-left: 20px; 
+    padding: 10px 20px; 
+    border-radius: 20px;
+    color: white; 
+    font-weight: bold; 
+    display: flex;
+    align-items: center;
+    gap: 8px; 
+    border: none; 
+}
+
+#create_listing_btn::before {
+    content: "+"; 
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+    background-color: white; 
+    color: #11407e; 
+    font-size: 18px; 
+    font-weight: bold;
+    text-align: center;
+    line-height: 20px; 
+    border-radius: 50%;
+    line-height: 0.95;
+
+}

--- a/Time_Banking/Time_Banking/templates/create_listing.html
+++ b/Time_Banking/Time_Banking/templates/create_listing.html
@@ -72,7 +72,7 @@ Create listing - Time Banking
                         <!-- Tags will be populated here dynamically -->
                     </select>
                 </div><br>
-                <button type="submit" class="btn btn-primary btn-block create-account">Create Service</button>
+                <button type="submit" class="btn btn-primary btn-block create-account" id="submit-button">Create Service</button>
             </form>
 
             <div id="responseMessage"></div>
@@ -128,6 +128,9 @@ Create listing - Time Banking
                             responseMessage.classList.remove('error');
                             responseMessage.classList.add('success');
                             responseMessage.style.display = 'block';  
+                            
+                            const submitButton = document.getElementById('submit-button');
+                            // submitButton.disabled = true;
                             
                             // Wait for 5 seconds before redirecting
                             setTimeout(function() {

--- a/Time_Banking/Time_Banking/templates/create_listing.html
+++ b/Time_Banking/Time_Banking/templates/create_listing.html
@@ -131,7 +131,8 @@ Create listing - Time Banking
                             
                             // Wait for 5 seconds before redirecting
                             setTimeout(function() {
-                                window.location.href = '/'; // Redirect to the home page
+                                const redir_url = `/listing/${data.id}`;
+                                window.location.href = redir_url; 
                             }, 5000); 
                         } else if (data.error) {
                             // Show error message

--- a/Time_Banking/Time_Banking/templates/master.html
+++ b/Time_Banking/Time_Banking/templates/master.html
@@ -33,6 +33,9 @@
                     </div>
                 </div>
             </form>
+            <div class="create_listing">
+                <a href="{% url 'create_listing_page' %}" class="btn btn-primary" id="create_listing_btn">Create A Offer/Request</a>
+            </div>
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav ml-auto">
                     {% if user.is_authenticated %}

--- a/Time_Banking/Time_Banking/templates/master.html
+++ b/Time_Banking/Time_Banking/templates/master.html
@@ -159,5 +159,8 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.3/dist/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+    {% block extra_scripts %}
+    {% endblock %}
 </body>
 </html>

--- a/Time_Banking/Time_Banking/templates/user_settings.html
+++ b/Time_Banking/Time_Banking/templates/user_settings.html
@@ -1,91 +1,21 @@
+{% extends "master.html" %}
 {% load static %}
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Settings - Time Banking</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
-    <link rel="stylesheet" href="{% static 'css/style.css' %}">
-    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
-    <link rel="stylesheet" href="{% static 'css/usersettings.css' %}">
 
-</head>
-<body>
-    <header>
-        <nav class="navbar navbar-expand-lg navbar-light bg-light">
-            <a class="navbar-brand" href="#">
-                <img src="/static/images/Logo.png" alt="Logo" height="30">
-            </a>
-            <form class="form-inline mx-auto">
-                <div class="input-group">
-                    <input class="searchbar" type="search" placeholder="What service are you looking for today?" aria-label="Search" style="width: 400px;">
-                    <div class="input-group-append">
-                        <button class="btn btn-dark search" type="submit">
-                            <i class="fa-solid fa-search"></i>
-                        </button>
-                    </div>
-                </div>
-            </form>
-            <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="navbar-nav ml-auto">
-                    {% if user.is_authenticated %}
-                        <!-- User Profile Icon with Dropdown Menu -->
-                        <li class="nav-item dropdown">
-                            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                <!-- User's Profile Text -->
-                                <span>Hi, {{ user.username }}</span>
-                            </a>
-                            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-                                <a class="dropdown-item" href="{% url 'profile_info' %}">Profile</a>
+{% block title %}
+User Settings - Time Banking
+{% endblock %}
 
-                                
-                                <a class="dropdown-item" href="/settings">Settings</a>
-                                <div class="dropdown-divider"></div>
-                                <form action="{% url 'logout' %}" method="post" class="dropdown-item">
-                                    {% csrf_token %}
-                                    <button type="submit" class="btn btn-link p-0" style="color: inherit; text-decoration: none;">Log Out</button>
-                                </form>
-                            </div>
-                        </li>
-                    {% else %}
-                    <li class="nav-item">
-                        <a class="btn" href="{% url 'create_account' %}" role="button">Create Account</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="btn" href="{% url 'login' %}" role="button">Sign In</a>
-                    </li>
-                    {% endif %}
-                </ul>
-            </div>
-        </nav>
-        
-        <!-- Navigation Links Below Header -->
-        <div class="container-fluid bg-light">
-            <div class="row">
-                <div class="col text-center py-2">
-                    <a href="#">Graphics & Design</a> |
-                    <a href="#">Programming & Tech</a> |
-                    <a href="#">Digital Marketing</a> |
-                    <a href="#">Video & Animation</a> |
-                    <a href="#">Writing & Translation</a> |
-                    <a href="#">Music & Audio</a> |
-                    <a href="#">Business</a> |
-                    <a href="#">Finance</a> |
-                    <a href="#">AI Services</a> |
-                    <a href="#">Personal Growth</a>
-                </div>
-            </div>
-        </div>
-    </header>
+{% block extra_links %}
+<link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+<link rel="stylesheet" href="{% static 'css/usersettings.css' %}">
+{% endblock %}
 
-
+{% block content %}
     <div class="body">
     <div class="containerset">
         <div class="header">
             <div class="title">Settings</div>
-            <div class="gotoprofile">Need to update your public profile? <a class="link" hef="#">Go to My Profile</a></div>
+            <div class="gotoprofile">Need to update your public profile? <a class="link" href="{% url 'profile_info' %}">Go to My Profile</a></div>
         </div>
         <div style="display: none;">
         <div class="subtitle">Account Information</div>
@@ -245,78 +175,10 @@
     </div>
     </div>
 
+{% endblock %}
 
-    <footer>
-        <div class="footer-container">
-            <!-- Footer Section 1 -->
-            <div class="footer-section">
-                <h3>Programming & Tech</h3>
-                <ul>
-                    <li><a href="#">Web Development</a></li>
-                    <li><a href="#">Data Science</a></li>
-                    <li><a href="#">AI Services</a></li>
-                </ul>
-            </div>
-            <!-- Footer Section 2 -->
-            <div class="footer-section">
-                <h3>Digital Marketing</h3>
-                <ul>
-                    <li><a href="#">Social Media</a></li>
-                    <li><a href="#">SEO</a></li>
-                    <li><a href="#">Content Marketing</a></li>
-                </ul>
-            </div>
-            <!-- Footer Section 3 -->
-            <div class="footer-section">
-                <h3>Writing & Translation</h3>
-                <ul>
-                    <li><a href="#">Proofreading</a></li>
-                    <li><a href="#">Copywriting</a></li>
-                    <li><a href="#">Translation</a></li>
-                </ul>
-            </div>
-            <!-- Footer Section 4 -->
-            <div class="footer-section">
-                <h3>Business</h3>
-                <ul>
-                    <li><a href="#">Consulting</a></li>
-                    <li><a href="#">Project Management</a></li>
-                    <li><a href="#">Financial Services</a></li>
-                </ul>
-            </div>
-            <!-- More sections as needed -->
-            <div class="footer-section">
-                <h3>Company</h3>
-                <ul>
-                    <li><a href="#">About Us</a></li>
-                    <li><a href="#">Terms of service</a></li>
-                    <li><a href="#">Privacy Policy</a></li>
-                    <li><a href="#">Help and Support</a></li>
-                </ul>
-            </div>
-        </div>
-        </div>
-        
-        <!-- Footer Bottom -->
-        <!-- Modified Footer Structure -->
-    <footer class="footer bg-dark text-center py-3">
-    <div class="container d-flex justify-content-between align-items-center">
-        <p class="text-light mb-0">© 2024 All rights reserved.</p>
-        <ul class="social-icons list-inline mb-0">
-            <li class="list-inline-item"><a href="#"><i class="fab fa-facebook"></i></a></li>
-            <li class="list-inline-item"><a href="#"><i class="fab fa-twitter"></i></a></li>
-            <li class="list-inline-item"><a href="#"><i class="fab fa-instagram"></i></a></li>
-        </ul>
-    </div>
-    </footer>
 
-    </footer>
-
-    <!-- Bootstrap JS and dependencies -->
-    <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.3/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-
+{% block extra_scripts%}
     <!-- 引入 jQuery 和 Select2 -->
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
@@ -515,5 +377,5 @@
             });
         })
     </script>
-</body>
-</html>
+{% endblock %}
+

--- a/Time_Banking/Time_Banking/tests/test_create_listing.py
+++ b/Time_Banking/Time_Banking/tests/test_create_listing.py
@@ -5,11 +5,11 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from datetime import timedelta
 import tempfile
 import shutil
+import random
 
 TEMP_MEDIA_ROOT = tempfile.mkdtemp()
 
 
-@override_settings(MEDIA_ROOT=TEMP_MEDIA_ROOT) # make sure the image is saved in the temp directory
 class CreateListingViewTests(TestCase):
 
     def setUp(self):
@@ -21,11 +21,12 @@ class CreateListingViewTests(TestCase):
         self.tag2 = Tag.objects.create(name="Tag2")
         
         
+    @override_settings(DISABLE_RATE_LIMIT_CHECK=True)
     def test_create_listing_with_valid_data(self):
         # Prepare a valid request payload
         image = SimpleUploadedFile("test_image.jpg", b"file_content", content_type="image/jpeg")
         data = {
-            'title': 'Test Listing',
+            'title': 'Test Listing with valid data',
             'category': Category.GRAPHICS_DESIGN,  # Use TextChoices
             'description': 'This is a test description',
             'image': image,
@@ -41,23 +42,76 @@ class CreateListingViewTests(TestCase):
         # Verify that listing was created successfully
         self.assertEqual(response.status_code, 201)
         self.assertIn('id', response.json())
-        self.assertEqual(response.json()['title'], 'Test Listing')
+        self.assertEqual(response.json()['title'], 'Test Listing with valid data')
+        self.assertEqual(response.json()['description'], 'This is a test description')
+    
+        self.assertEqual(response.json()['listing_type'], 'Offer')
+        self.assertEqual(response.json()['duration'], '2:00:00')
 
-        
         self.assertQuerySetEqual(response.json()['tags'], [str(self.tag1), str(self.tag2)], ordered=False)
+        Listing.objects.all().delete()
         
         
+    @override_settings(DISABLE_RATE_LIMIT_CHECK=True)
+    def test_create_listing_with_random_data(self):
+        # Prepare a valid request payload
+        image = SimpleUploadedFile("test_image.jpg", b"file_content", content_type="image/jpeg")
+        used_titles = []
+        # Randomize the data
+        for _ in range(10):
+            title = 'Test Listing with random data' + str(random.randint(1, 1000))
+            if title in used_titles:
+                continue
+            used_titles.append(title)
+            category = random.choice(Category.choices)[0]
+            description = 'This is a test description ' + str(random.randint(1, 10000000000))
+            listing_type = random.choice(['True', 'False'])
+            duration = str(random.randint(1, 10))
+            tags = [self.tag1.id, self.tag2.id]
+            
+            data = {
+                'title': title,
+                'category': category,
+                'description': description,
+                'image': image,
+                'listing_type': listing_type,
+                'duration': duration,
+                'tags': tags,
+            }
+            
+            response = self.client.post(reverse('create_listing'), data)
+            
+            # print(response.json())  # print response for debugging
+
+            # Verify that listing was created successfully
+            self.assertEqual(response.status_code, 201)
+            self.assertIn('id', response.json())
+            self.assertEqual(response.json()['title'], title)
+            self.assertEqual(response.json()['description'], description)
+            listing_type = "Offer" if listing_type == 'True' else "Request"
+            self.assertEqual(response.json()['listing_type'], listing_type)
+            self.assertEqual(response.json()['duration'], str(timedelta(hours=int(duration))))
+            self.assertQuerySetEqual(response.json()['tags'], [str(self.tag1), str(self.tag2)], ordered=False)
+            
+        Listing.objects.all().delete()
+        
+        
+    @override_settings(DISABLE_RATE_LIMIT_CHECK=True)
     def test_create_listing_with_missing_required_fields(self):
-        title = 'Test Listing'
+        
         category = Category.GRAPHICS_DESIGN
         description = 'This is a test description'
         listing_type = 'True'
         duration = '2'
         image = SimpleUploadedFile("test_image.jpg", b"file_content", content_type="image/jpeg")
-
+        used_titles = []
         for i in range(6):
+            titles = 'Test Listing with missing field' + str(random.randint(1, 1000))
+            while titles in used_titles:
+                titles = 'Test Listing with missing field' + str(random.randint(1, 1000))
+            used_titles.append(titles)
             data = {
-                'title': title,
+                'title': titles,
                 'category': category,
                 'description': description,
                 'listing_type': listing_type,
@@ -74,16 +128,23 @@ class CreateListingViewTests(TestCase):
             self.assertNotEqual(response.status_code, 201)
             self.assertIn('error', response.json())
             self.assertTrue('Missing required fields' in response.json()['error'])
+        Listing.objects.all().delete()
         
         
+    @override_settings(DISABLE_RATE_LIMIT_CHECK=True)
     def test_create_listing_with_duration(self):
         # Invalid duration format (non-integer)
         image = SimpleUploadedFile("test_image.jpg", b"file_content", content_type="image/jpeg")
 
         invalid_duration_field = ['two', '2.5', '2.0', '2.5h', '2h30m', '2h 30m', '2 hours', '2 hours 30 minutes']
+        used_titles = []
         for duration in invalid_duration_field:
+            titles = 'Test Listing with invalid duration' + str(random.randint(1, 1000))
+            while titles in used_titles:
+                titles = 'Test Listing with invalid duration' + str(random.randint(1, 1000))
+            used_titles.append(titles)
             data = {
-                'title': 'Test Listing',
+                'title': titles,
                 'category': Category.PROGRAMMING_TECH,
                 'description': 'This is a test description',
                 'listing_type': 'True',
@@ -98,9 +159,14 @@ class CreateListingViewTests(TestCase):
             self.assertIn('error', response.json())
 
         right_duration = ['2', '30', '60', '120']
+        used_titles = []
         for duration in right_duration:
+            titles = 'Test Listing  with different duration ' + str(random.randint(1, 1000))
+            while titles in used_titles:
+                titles = 'Test Listing with different duration ' + str(random.randint(1, 1000))
+            used_titles.append(titles)
             data = {
-                'title': 'Test Listing',
+                'title': titles,
                 'category': Category.PROGRAMMING_TECH,
                 'description': 'This is a test description',
                 'listing_type': 'True',
@@ -113,9 +179,11 @@ class CreateListingViewTests(TestCase):
             # Verify response status and error message
             self.assertEqual(response.status_code, 201)
             self.assertIn('id', response.json())
-            self.assertEqual(response.json()['title'], 'Test Listing')
+            self.assertEqual(response.json()['duration'], str(timedelta(hours=int(duration))))
+        Listing.objects.all().delete()
             
             
+    @override_settings(DISABLE_RATE_LIMIT_CHECK=True)
     def test_create_listing_with_exceeding_description_length(self):
         # Description exceeding 5000 characters
         image = SimpleUploadedFile("test_image.jpg", b"file_content", content_type="image/jpeg")
@@ -134,6 +202,7 @@ class CreateListingViewTests(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('error', response.json())
         self.assertEqual(response.json()['error'], 'Description is too long')
+        Listing.objects.all().delete()
 
 
     def test_create_listing_with_non_post_request(self):
@@ -144,4 +213,106 @@ class CreateListingViewTests(TestCase):
         self.assertEqual(response.status_code, 405)
         self.assertIn('error', response.json())
         self.assertEqual(response.json()['error'], 'POST request required')
+        Listing.objects.all().delete()
+        
+    
+    def test_create_listing_with_too_frequent_requests(self):
+        # Prepare a valid request payload
+        image = SimpleUploadedFile("test_image.jpg", b"file_content", content_type="image/jpeg")
+        datas = []
+        used_titles = []
+        
+        for i in range(10):
+            titles = 'Test Listing with too frequent test' + str(random.randint(1, 1000000))
+            while titles in used_titles:
+                titles = 'Test Listing with too frequent test' + str(random.randint(1, 1000000))
+            used_titles.append(titles)
+            datas.append({
+                'title': titles,
+                'category': Category.GRAPHICS_DESIGN,  # Use TextChoices
+                'description': 'This is a test description',
+                'image': image,
+                'listing_type': 'True',
+                'duration': '2',
+                'tags': [self.tag1.id, self.tag2.id],
+            })
+
+
+        # Send 10 requests in quick succession
+        for i in range(10):
+            response = self.client.post(reverse('create_listing'), datas[i])
+        
+        # Verify that the last request was rate-limited
+        self.assertEqual(response.status_code, 429)
+        self.assertIn('error', response.json())
+        self.assertEqual(response.json()['error'], 'You are creating services too quickly.')
+        Listing.objects.all().delete()
+        
+        
+    @override_settings(DISABLE_RATE_LIMIT_CHECK=True)
+    def test_create_listing_with_same_title(self):
+        # Prepare a valid request payload
+        image = SimpleUploadedFile("test_image.jpg", b"file_content", content_type="image/jpeg")
+        data = {
+            'title': 'Test Listing with same title',
+            'category': Category.GRAPHICS_DESIGN,  # Use TextChoices
+            'description': 'This is a test description',
+            'image': image,
+            'listing_type': 'True',
+            'duration': '2',
+            'tags': [self.tag1.id, self.tag2.id],
+        }
+
+        response = self.client.post(reverse('create_listing'), data)
+        
+        # Verify that listing was created successfully
+        self.assertEqual(response.status_code, 201)
+        
+        # Try to create another listing with the same title
+        response = self.client.post(reverse('create_listing'), data)
+        
+        # Verify that the second request failed
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', response.json())
+        self.assertEqual(response.json()['error'], 'You are trying to create a service with duplicated title.')
+        Listing.objects.all().delete()
+        
+    
+    @override_settings(DISABLE_RATE_LIMIT_CHECK=True)
+    def test_create_listing_with_too_many_listings(self):
+        # remove all old listings
+        Listing.objects.all().delete()
+        image = SimpleUploadedFile("test_image.jpg", b"file_content", content_type="image/jpeg")
+        datas = []
+        used_titles = []
+        for i in range(301):
+            titles = 'Test Listing with too many listings' + str(random.randint(1, 1000000))
+            while titles in used_titles:
+                titles = 'Test Listing with too many listings' + str(random.randint(1, 1000000))
+            used_titles.append(titles)
+            datas.append({
+                'title': titles,
+                'category': Category.GRAPHICS_DESIGN,  # Use TextChoices
+                'description': 'This is a test description',
+                'listing_type': 'True',
+                'duration': '2',
+                'tags': [self.tag1.id, self.tag2.id],
+                'image': image,
+            })
+            
+        for i in range(300):
+            response = self.client.post(reverse('create_listing'), datas[i])
+            self.assertEqual(response.status_code, 201)
+            
+            
+        # Try to create another listing
+        response = self.client.post(reverse('create_listing'), datas[300])
+        
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', response.json())
+        self.assertEqual(response.json()['error'], 'You have reached the maximum number of services.')
+        Listing.objects.all().delete()
+        
+        
+    
         

--- a/Time_Banking/Time_Banking/tests/test_user_settings.py
+++ b/Time_Banking/Time_Banking/tests/test_user_settings.py
@@ -1,0 +1,125 @@
+from django.test import TestCase, Client, override_settings
+from ..models import Listing, User, ListingResponse, ListingAvailability, Category, Tag
+from django.urls import reverse
+from django.core.files.uploadedfile import SimpleUploadedFile
+from datetime import timedelta
+import tempfile
+import shutil
+import random
+import json
+
+
+class UserSettingsTests(TestCase):
+    
+    Old_password = 'OldPassword123!'
+    New_password = 'NewPassword123!'
+    
+    def setUp(self):
+        self.client = Client()
+        
+        # Create a user for testing
+        self.user = User.objects.create_user(username="testuser", password=self.Old_password)
+        self.client.login(username="testuser", password=self.Old_password)
+        
+    def test_change_valid_password(self):
+        # Test changing the password with valid data
+        response = self.client.post(
+            reverse('change_password'), 
+            json.dumps({
+                "username": "testuser",
+                "current_password": self.Old_password,
+                "new_password": self.New_password,
+                "confirm_password": self.New_password,
+            }),
+            content_type='application/json' 
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'status': 'success'})
+        
+        self.client.logout()
+        login_response = self.client.login(username="testuser", password=self.New_password)
+        self.assertTrue(login_response) 
+
+        profile_response = self.client.get(reverse('profile_info'))
+        self.assertEqual(profile_response.status_code, 200)
+        
+    def test_change_invalid_password(self):
+        response = self.client.post(
+            reverse('change_password'), 
+            json.dumps({
+                "username": "testuser",
+                "current_password": self.New_password,
+                "new_password": "12345678",
+                "confirm_password": "12345678",
+            }),
+            content_type='application/json'  
+        )
+        
+        self.assertEqual(response.status_code, 400)
+
+    
+    def test_change_password_with_incorrect_current_password(self):
+        response = self.client.post(
+            reverse('change_password'), 
+            json.dumps({
+                "username": "testuser",
+                "current_password": "incorrect_password",
+                "new_password": self.New_password,
+                "confirm_password": self.New_password,
+            }),
+            content_type='application/json'  
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'error': 'Current password is incorrect'})
+        
+        
+    def test_change_password_not_post(self):
+        response = self.client.get(reverse('change_password'))
+        self.assertEqual(response.status_code, 405)
+    
+        
+    def test_change_password_with_mismatched_new_passwords(self):
+        response = self.client.post(
+            reverse('change_password'), 
+            json.dumps({
+                "username": "testuser",
+                "current_password": self.New_password,
+                "new_password": self.New_password,
+                "confirm_password": "12345678",
+            }),
+            content_type='application/json'  
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'error': 'New passwords do not match'})
+        
+    def test_change_password_not_own(self):
+        # Test changing the password of another user
+        other_user = User.objects.create_user(username="otheruser", password="password")
+        
+        response = self.client.post(
+            reverse('change_password'), 
+            json.dumps({
+                "username": "otheruser",
+                "current_password": "password",
+                "new_password": self.New_password,
+                "confirm_password": self.New_password,
+            }),
+            content_type='application/json'  
+        )
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json(), {'error': 'Not authorized to change password'})
+        
+        
+    def test_delete_account(self):
+        response = self.client.post(reverse('delete_account'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {'status': 'Account deleted successfully'})
+        
+        login_response = self.client.login(username="testuser", password=self.New_password)
+        self.assertFalse(login_response)
+        
+    def test_delete_account_not_post(self):
+        response = self.client.get(reverse('delete_account'))
+        self.assertEqual(response.status_code, 405)
+        
+        

--- a/Time_Banking/Time_Banking/views.py
+++ b/Time_Banking/Time_Banking/views.py
@@ -9,6 +9,7 @@ from django.contrib.auth import authenticate, login
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
+from django.conf import settings
 import uuid
 from .models import Listing, User, ListingResponse, ListingAvailability, Category, Tag
 from .forms import RegisterForm, ProfileCreationForm, ProfileEditForm
@@ -252,6 +253,9 @@ def change_password(request):
             current_password = data.get('current_password')
             new_password = data.get('new_password')
             confirm_password = data.get('confirm_password')
+            
+            if username != request.user.username:
+                return JsonResponse({'error': 'Not authorized to change password'}, status=403)
             
             if new_password != confirm_password:
                 return JsonResponse({'error': 'New passwords do not match'}, status=400)
@@ -552,6 +556,19 @@ def create_listing(request):
                 duration = timedelta(hours=duration_in_hours)  # Convert to timedelta
             except ValueError:
                 return JsonResponse({'error': 'Duration must be a valid integer'}, status=400)
+            
+        
+            
+            
+            # check listing is valid to create or not
+            user_listings_old = Listing.objects.filter(creator=request.user)
+            if len(user_listings_old) > 0:
+                if len(user_listings_old) > 299:
+                    return JsonResponse({'error': 'You have reached the maximum number of services.'}, status=400)
+                for user_listing in user_listings_old:
+                    if user_listing.title == title:
+                        return JsonResponse({'error': 'You are trying to create a service with duplicated title.'}, status=400)
+                latest_listing_posted_at = user_listings_old.latest('posted_at').posted_at
 
             listing = Listing.objects.create(
                 creator=request.user,  
@@ -562,8 +579,15 @@ def create_listing(request):
                 listing_type=listing_type,
                 duration=duration
             )
-
-
+            
+            # check if the user is creating services too quickly 30 seconds
+            if not getattr(settings, 'DISABLE_RATE_LIMIT_CHECK', False): # Disable rate limit check for test cases
+                if len(user_listings_old) > 0:
+                    if latest_listing_posted_at > listing.posted_at - timedelta(seconds=30):
+                        listing.delete()
+                        return JsonResponse({'error': 'You are creating services too quickly.'}, status=429)
+            
+            
             listing.save() # save the listing to the database
 
             if tag_ids:


### PR DESCRIPTION
<!-- Try to fill out everything! -->

## What does this pull request include?

1. Add an entrypoint in top bar for accessing "create listing"
2. After successfully created the listing, it will be redirected to the detail page of the listing (I think it is more reasonable)
3. Fix the bugs of user settings page.

Edit, Add in 11/12/2024:
1. Fix bugs for duplicated creation of listings. (fronted end disable the button)
2. Add more restrictions to create listings (Not allowed: duplicated title, total listings > 300, request too frequent in 30s)
3. Add more comprehensive test cases for listing creations
4. Create the test cases for change password and delete account

In this PR, only frontend is involved. No modification for backend.

<!-- List the features you did -->

## Any outstanding issues in this pull request?
Refer to #48 

<!-- List anything you want others to fix -->

## Checklist

- [x] Test locally
- [x] Assign a reviewer
- [ ] ZenHub
