### PR TITLE
create_listing duration input change to minutes from hours

### DIFF
--- a/Time_Banking/Time_Banking/templates/create_listing.html
+++ b/Time_Banking/Time_Banking/templates/create_listing.html
@@ -57,7 +57,7 @@ Create listing - Time Banking
                 </div>
                 <div class="form-group">
                     <!-- Duration -->
-                    <label for="duration">Duration (in hours):</label>
+                    <label for="duration">Duration (in minutes):</label>
                     <input type="number" id="duration" name="duration" min="1" required>
                 </div>
                 <div class="form-group">

--- a/Time_Banking/Time_Banking/tests/test_create_listing.py
+++ b/Time_Banking/Time_Banking/tests/test_create_listing.py
@@ -46,7 +46,7 @@ class CreateListingViewTests(TestCase):
         self.assertEqual(response.json()['description'], 'This is a test description')
     
         self.assertEqual(response.json()['listing_type'], 'Offer')
-        self.assertEqual(response.json()['duration'], '2:00:00')
+        self.assertEqual(response.json()['duration'], '0:02:00')
 
         self.assertQuerySetEqual(response.json()['tags'], [str(self.tag1), str(self.tag2)], ordered=False)
         Listing.objects.all().delete()
@@ -89,7 +89,7 @@ class CreateListingViewTests(TestCase):
             self.assertEqual(response.json()['title'], title)
             self.assertEqual(response.json()['description'], description)
             self.assertEqual(response.json()['listing_type'], listing_type)
-            self.assertEqual(response.json()['duration'], str(timedelta(hours=int(duration))))
+            self.assertEqual(response.json()['duration'], str(timedelta(minutes=int(duration))))
             self.assertQuerySetEqual(response.json()['tags'], [str(self.tag1), str(self.tag2)], ordered=False)
             
         Listing.objects.all().delete()
@@ -178,7 +178,7 @@ class CreateListingViewTests(TestCase):
             # Verify response status and error message
             self.assertEqual(response.status_code, 201)
             self.assertIn('id', response.json())
-            self.assertEqual(response.json()['duration'], str(timedelta(hours=int(duration))))
+            self.assertEqual(response.json()['duration'], str(timedelta(minutes=int(duration))))
         Listing.objects.all().delete()
             
             

--- a/Time_Banking/Time_Banking/views.py
+++ b/Time_Banking/Time_Banking/views.py
@@ -511,10 +511,10 @@ def create_listing(request):
             description = request.POST.get('description')
             image = request.FILES.get('image')  # We can only have 1 image per listing
             listing_type = request.POST.get('listing_type')  # Expecting 'True' or 'False'
-            duration_in_hours = request.POST.get('duration')  # Expected format: integer (hours)
+            duration_in_minutes = request.POST.get('duration')  # Expected format: integer (minutes)
             tag_ids = request.POST.getlist('tags')  # Expecting a list of tag IDs
 
-            if not title or not category_id or not description or not image or not listing_type or not duration_in_hours:
+            if not title or not category_id or not description or not image or not listing_type or not duration_in_minutes:
                 missing_fields = [field for field in ['title', 'category', 'description', 'image', 'listing_type', 'duration'] if not request.POST.get(field)]
                 error_msg = f'Missing required fields: {", ".join(missing_fields)}'
                 return JsonResponse({'error': error_msg}, status=400)
@@ -528,8 +528,8 @@ def create_listing(request):
             category = Category(category_id).label
 
             try:
-                duration_in_hours = int(duration_in_hours)  # Ensure it's an integer
-                duration = timedelta(hours=duration_in_hours)  # Convert to timedelta
+                duration_in_minutes = int(duration_in_minutes)  # Ensure it's an integer
+                duration = timedelta(minutes=duration_in_minutes)  # Convert to timedelta
             except ValueError:
                 return JsonResponse({'error': 'Duration must be a valid integer'}, status=400)
             


### PR DESCRIPTION
<!-- Try to fill out everything! -->

## What does this pull request include?

Changed the input field "duration" of create_listing from unit hours to minutes as requesed

<!-- List the features you did -->

## Any outstanding issues in this pull request?

Unknown

<!-- List anything you want others to fix -->

## Checklist

- [x] Test locally
- [x] Assign a reviewer
- [x] GitHub Projects
